### PR TITLE
Don’t process files without requires

### DIFF
--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -55,7 +55,7 @@ module BrowserifyRails
     # Be here as strict as possible, so that non-commonjs files are not
     # preprocessed.
     def commonjs_module?
-      data.to_s.include?("module.exports") || data.present? && dependencies.length > 0
+      data.to_s.include?("module.exports") || data.present? && data.to_s.include?("require") && dependencies.length > 0
     end
 
     # This primarily filters out required files from node modules


### PR DESCRIPTION
Shelling out to fetch dependencies is pretty slow when you have large amount of files to process. This could be speed up by ignoring files without requires. The proposed approach does not distinguish between Sprockets and Browserify requires, but at least in my case seems to be very efficient.
