### PR TITLE
Bump referenced Browserify version to 5.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Create `package.json` in your Rails root:
 {
   "name": "something",
   "devDependencies" : {
-    "browserify": "~> 5.13"
+    "browserify": "~> 6.3"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
I changed the README to mention the existence of version `0.5` of this gem, together with the fact you can use version `5.x` of browserify with it. 

I haven't tested the actual use of this specific version myself (although I'm starting to work on porting a codebase to it now), so I can also confirm whether or not it actually works in a while.

I've referenced version `5.13` of browserify because it's the last `5.x` release. Is there ever going to be support for `6.x`?
