### PR TITLE
Refactor browserify_processor to allow using browserifyinc

### DIFF
--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -96,7 +96,7 @@ module BrowserifyRails
       @dependencies ||= begin
         # We forcefully run browserify (avoiding browserifyinc) with the --list
         # option to get a list of files.
-        list = run_browserify(nil, "--list", false)
+        list = run_browserify(nil, "--list")
 
         list.lines.map(&:strip).select do |path|
           # Filter the temp file, where browserify caches the input stream

--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -1,37 +1,55 @@
 require "open3"
+require "fileutils"
+require "tempfile"
 
 module BrowserifyRails
   class BrowserifyProcessor < Tilt::Template
-    BROWSERIFY_CMD = "./node_modules/.bin/browserify".freeze
+    NODE_BIN = "node_modules/.bin/"
+
+    BROWSERIFY_CMD    = File.join(NODE_BIN, "browserify").freeze
+    BROWSERIFYINC_CMD = File.join(NODE_BIN, "browserifyinc").freeze
+
+    TMP_PATH = File.join("tmp/browserify-rails").freeze
 
     def prepare
-      @config = Rails.application.config.browserify_rails_granular
+      ensure_tmp_dir_exists!
+      ensure_commands_exist!
     end
 
     def evaluate(context, locals, &block)
-      if should_browserify?
-        asset_dependencies(context.environment.paths).each do |path|
-          context.depend_on(path)
-        end
+      # If there's nothing to do, we just return the data we received
+      return data unless should_browserify?
 
-        browserify context.logical_path
-      else
-        data
+      # Signal dependencies to sprockets to ensure we track changes
+      asset_dependencies(context.environment.paths).each do |path|
+        context.depend_on(path)
       end
+
+      run_browserify(context.logical_path)
     end
 
-    private
+  private
 
-    def asset_paths
-      @asset_paths ||= Rails.application.config.assets.paths.collect { |p| p.to_s }.join(":") || ""
+    def config
+      Rails.application.config.browserify_rails
     end
 
-    def has_config?(logical_path)
-      @config.has_key?("javascript") && @config["javascript"].has_key?(logical_path)
+    def ensure_tmp_dir_exists!
+      FileUtils.mkdir_p(rails_path(TMP_PATH))
     end
 
-    def get_config(logical_path)
-      @config["javascript"][logical_path] if @config.has_key?("javascript")
+    def ensure_commands_exist!
+      error = ->(cmd) { "Unable to run #{cmd}. Ensure you have installed it with npm." }
+
+      # Browserify has to be installed in any case
+      if !File.exists?(rails_path(BROWSERIFY_CMD))
+        raise BrowserifyRails::BrowserifyError.new(error.call(BROWSERIFY_CMD))
+      end
+
+      # If the user wants to use browserifyinc, we need to ensure it's there too
+      if config.use_browserifyinc && !File.exists?(rails_path(BROWSERIFYINC_CMD))
+        raise BrowserifyRails::BrowserifyError.new(error.call(BROWSERIFYINC_CMD))
+      end
     end
 
     def should_browserify?
@@ -58,6 +76,10 @@ module BrowserifyRails
       data.to_s.include?("module.exports") || data.present? && data.to_s.include?("require") && dependencies.length > 0
     end
 
+    def asset_paths
+      @asset_paths ||= Rails.application.config.assets.paths.collect { |p| p.to_s }.join(":") || ""
+    end
+
     # This primarily filters out required files from node modules
     #
     # @return [<String>] Paths of dependencies, that are in asset directories
@@ -69,27 +91,20 @@ module BrowserifyRails
 
     # @return [<String>] Paths of files, that this file depends on
     def dependencies
-      @dependencies ||= run_browserify("#{options} --list").lines.map(&:strip).select do |path|
-        # Filter the temp file, where browserify caches the input stream
-        File.exists?(path)
+      @dependencies ||= begin
+        # We forcefully run browserify (avoiding browserifyinc) with the --list
+        # option to get a list of files.
+        list = run_browserify(nil, "--list", false)
+
+        list.lines.map(&:strip).select do |path|
+          # Filter the temp file, where browserify caches the input stream
+          File.exists?(path)
+        end
       end
     end
 
-    def browserify(logical_path)
-      run_browserify(options, logical_path)
-    end
-
-    def browserify_cmd
-      cmd = File.join(Rails.root, BROWSERIFY_CMD)
-
-      if !File.exist?(cmd)
-        raise BrowserifyRails::BrowserifyError.new("browserify could not be found at #{cmd}. Please run npm install.")
-      end
-
-      cmd
-    end
-
-    # Run browserify with `data` on standard input.
+    # Run the requested version of browserify (browserify or browserifyinc)
+    # based on configuration or the use_browserifyinc parameter if present.
     #
     # We are passing the data via stdin, so that earlier preprocessing steps are
     # respected. If you had, say, an "application.js.coffee.erb", passing the
@@ -99,32 +114,61 @@ module BrowserifyRails
     # javascript at the time this processor is called.
     #
     # @raise [BrowserifyRails::BrowserifyError] if browserify does not succeed
-    # @param options [String] Options for browserify
-    # @return [String] Output on standard out
-    def run_browserify(options, logical_path=nil)
-      if has_config?(logical_path)
-        config = get_config logical_path
+    # @param logical_path [String] Sprockets's logical path for the file
+    # @param extra_options [String] Options to be included in the command
+    # @param force_browserifyinc [Boolean] Causes browserifyinc to be used if true
+    # @return [String] Output of the command
+    def run_browserify(logical_path=nil, extra_options=nil, force_browserifyinc=nil)
+      command_options = "#{options} #{extra_options} #{granular_options(logical_path)}".strip
 
-        granular_options = config.keys.collect do |key|
-          config[key].collect { |value| "--#{key} #{value}" }
-        end
-
-        options += " " + granular_options.join(" ")
+      # Browserifyinc uses a special cache file. We set up the path for it if
+      # we're going to use browserifyinc.
+      if uses_browserifyinc(force_browserifyinc)
+        cache_file_path = rails_path(TMP_PATH, "browserifyinc-cache.json")
+        command_options << " --cachefile=#{cache_file_path.inspect}"
       end
 
-      directory = File.dirname(file)
-      command = "#{browserify_cmd} #{options} -"
+      # Create a temporary file for the output. Such file is necessary when
+      # using browserifyinc, but we use it in all instances for consistency
+      output_file = Tempfile.new("output", rails_path(TMP_PATH))
+      command_options << " -o #{output_file.path.inspect}"
+
+      # Compose the full command (using browserify or browserifyinc as necessary)
+      command = "#{browserify_command(force_browserifyinc)} #{command_options} -"
+      env = { "NODE_PATH" => asset_paths }
+
+      # The directory the command will be executed from
+      base_directory = File.dirname(file)
+
       Logger::log "Browserify: #{command}"
-      env = {
-        "NODE_PATH" => asset_paths
-      }
-      stdout, stderr, status = Open3.capture3(env, command, stdin_data: data, chdir: directory)
+      stdout, stderr, status = Open3.capture3(env, command, stdin_data: data, chdir: base_directory)
 
       if !status.success?
         raise BrowserifyRails::BrowserifyError.new("Error while running `#{command}`:\n\n#{stderr}")
       end
 
-      stdout
+      # Read the output that was stored in the temp file
+      output = output_file.read
+
+      # Destroy the temp file (good practice)
+      output_file.close
+      output_file.unlink
+
+      # Some command flags (such as --list) make the output go to stdout,
+      # ignoring -o. If this happens, we give out stdout instead.
+      if stdout.present?
+        stdout
+      else
+        output
+      end
+    end
+
+    def uses_browserifyinc(force=nil)
+      force.present? ? force : config.use_browserifyinc
+    end
+
+    def browserify_command(force=nil)
+      rails_path(uses_browserifyinc(force) ? BROWSERIFYINC_CMD : BROWSERIFY_CMD)
     end
 
     def options
@@ -137,8 +181,25 @@ module BrowserifyRails
       options.uniq.join(" ")
     end
 
-    def config
-      BrowserifyRails::Railtie.config.browserify_rails
+    def get_granular_config(logical_path)
+      granular_config = config.granular["javascript"]
+
+      granular_config && granular_config[logical_path]
+    end
+
+    def granular_options(logical_path)
+      granular_config = get_granular_config(logical_path)
+
+      return nil if granular_config.blank?
+
+      # We set separate options for each of the items in granular_config
+      granular_config.keys.collect do |key|
+        granular_config[key].collect { |value| "--#{key} #{value}" }
+      end
+    end
+
+    def rails_path(*paths)
+      Rails.root.join(*paths).to_s
     end
   end
 end

--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -164,7 +164,7 @@ module BrowserifyRails
     end
 
     def uses_browserifyinc(force=nil)
-      force.present? ? force : config.use_browserifyinc
+      !force.nil? ? force : config.use_browserifyinc
     end
 
     def browserify_command(force=nil)

--- a/lib/browserify-rails/railtie.rb
+++ b/lib/browserify-rails/railtie.rb
@@ -9,11 +9,14 @@ module BrowserifyRails
     # Environments to generate source maps in
     config.browserify_rails.source_map_environments = ["development"]
 
+    # Use browserifyinc instead of browserify
+    config.browserify_rails.use_browserifyinc = false
+
     initializer :setup_browserify do |app|
       # Load granular configuration
       filename = File.join(Rails.root, 'config', 'browserify.yml')
       configuration = YAML::load(File.read(filename)) if File.exist? filename
-      config.browserify_rails_granular = configuration || {}
+      config.browserify_rails.granular = configuration || {}
 
       app.assets.register_postprocessor "application/javascript", BrowserifyRails::BrowserifyProcessor
     end


### PR DESCRIPTION
I made this PR as a follow-up to #31. Besides the list of changes you can see in the commit message below, I've done a general pass of refactoring because I saw that adding support for `browserifyinc` carried the risk of making the code messy, and I didn't want to handicap the library as a result. Please let me know what you think of the code, and I can apply any changes you suggest.

**The PR isn't ready to be merged yet, however:** when I run it with the `use_browserifyinc` option disabled, everything compiles fine as it used to before I modified it. I hopefully haven't introduced any regressions (I will need to run the test suite and ensure everything works). The issue I'm facing though is that when I enable the option and let the code compile, I will still get a result as I would with `browserify`, but it won't run at all (it will fail in the browser with a cryptic error, which I've also reported in jsdf/browserify-incremental#3.

@cymen If you are interested, I would like to ask you for your help in getting this to work, since if it actually works as advised it might be a huge step in speeding up the compilation times on our app, which are now touching the 30 seconds ceiling on *every single refresh.*

At the moment I feel like I'm out of places to look for the problem. My only unverified guess is that browserify-incremental is ignoring the options in my `package.json` (which contents are also included in jsdf/browserify-incremental#3). I will verify if that's the case and report back.

Do you have any clue what the problem may be?

----

Commit message with list of changes:

This commit alters the processor to accept a `use_browserifyinc` config option
which will cause the `browserifyinc` executable to run, as opposed to
`browserify`.

Other changes include:

 * The way options are passed around in the processor has been streamlined, and
   some of the related methods have been refactored to allow running both
   `browserify` and `browserifyinc` in a similar way.

 * Verification of the existence of both the `browserify` and `browserifyinc`
   commands has been moved to the `prepare` method.

 * The granular config data has been moved from
   `config.browserify_rails_granular` to `config.browserify_rails.granular`;

 * Browserify output is now always redirected to a temp file in the Rails `tmp/`
   directory, since browserifyinc requires it and for consistency. Some options
   (like `--list`) will always output to stdout, and that case is recognized and
   used when necessary;

 * Configuration parameters have been refactored to all be sourced from the same
   Rails object in the same way;