### PR TITLE
Add support for `forcing` browserifying

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ class My::Application < Rails::Application
   # The default is `false`
   config.browserify_rails.evaluate_node_modules = true
 
+  # Force browserify on every found JavaScript asset
+  #
+  # The default is `false`
+  config.browserify_rails.force = true
+
   # Command line options used when running browserify
   #
   # can be provided as an array:

--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -53,7 +53,7 @@ module BrowserifyRails
     end
 
     def should_browserify?
-      in_path? && !browserified? && commonjs_module?
+      config.force || (in_path? && !browserified? && commonjs_module?)
     end
 
     # Is this file in any of the configured paths?

--- a/lib/browserify-rails/railtie.rb
+++ b/lib/browserify-rails/railtie.rb
@@ -2,6 +2,9 @@ module BrowserifyRails
   class Railtie < Rails::Engine
     config.browserify_rails = ActiveSupport::OrderedOptions.new
 
+    # Always browserify every file
+    config.browserify_rails.force = false
+
     # Which paths should be browserified?
     config.browserify_rails.paths = [lambda { |p| p.start_with?(Rails.root.join("app").to_s) },
                                      lambda { |p| p.start_with?(Rails.root.join("node_modules").to_s) }]

--- a/test/compilation_test.rb
+++ b/test/compilation_test.rb
@@ -150,6 +150,12 @@ class BrowserifyTest < ActionController::IntegrationTest
     assert_equal fixture("browserified.out.js"), @response.body.strip
   end
 
+  test "skip files that should not be browserified" do
+    get "/assets/plain.js"
+
+    assert_equal fixture("plain.js"), @response.body.strip
+  end
+
   test "uses config/browserify.yml to mark a module as globally available via --require" do
     expected_output = fixture("main.out.js")
 

--- a/test/compilation_test.rb
+++ b/test/compilation_test.rb
@@ -12,6 +12,9 @@ class BrowserifyTest < ActionController::IntegrationTest
   setup do
     Rails.application.assets.cache = nil
 
+    # Reset config on each run
+    Dummy::Application.config.browserify_rails.force = false
+
     cache_file = File.join(Rails.root, "tmp/browserify-rails/browserifyinc-cache.json")
     File.delete(cache_file) if File.exists?(cache_file)
 
@@ -154,6 +157,13 @@ class BrowserifyTest < ActionController::IntegrationTest
     get "/assets/plain.js"
 
     assert_equal fixture("plain.js"), @response.body.strip
+  end
+
+  test "browserify even plain files if force == true" do
+    Dummy::Application.config.browserify_rails.force = true
+    get "/assets/plain.js"
+
+    assert_equal fixture("plain.out.js"), @response.body.strip
   end
 
   test "uses config/browserify.yml to mark a module as globally available via --require" do

--- a/test/dummy/app/assets/javascripts/plain.js
+++ b/test/dummy/app/assets/javascripts/plain.js
@@ -1,0 +1,1 @@
+var string = "good old, simple plain javascript. No fancy modules here";

--- a/test/fixtures/plain.js
+++ b/test/fixtures/plain.js
@@ -1,0 +1,1 @@
+var string = "good old, simple plain javascript. No fancy modules here";

--- a/test/fixtures/plain.out.js
+++ b/test/fixtures/plain.out.js
@@ -1,0 +1,4 @@
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({"__RAILS_ROOT__/app/assets/javascripts/_stream_0.js":[function(require,module,exports){
+var string = "good old, simple plain javascript. No fancy modules here";
+
+},{}]},{},["__RAILS_ROOT__/app/assets/javascripts/_stream_0.js"]);


### PR DESCRIPTION
Adds a new config variable `config.browserify_rails.force` which – when enabled – will force all assets to be browserified (default is false). Previously, only files with the `module.exports` string in them were browserified. With this change, you can force browserify-rails to browserify every JavaScript file.

Feel free to praise, nitpick, reject, brainstorm and pick the implementation apart :) This was a fairly quick addition and I will be using this branch in my own project(s) anyways.

(as discussed on #19)