### PR TITLE
Do not create source maps by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ class My::Application < Rails::Application
 
   # Environments, in which to generate source maps
   #
-  # The default is `["development"]`.
-  config.browserify_rails.source_map_environments << "production"
+  # The default is none
+  config.browserify_rails.source_map_environments << "development"
 
   # Should the node_modules directory be evaluated for changes on page load
   #

--- a/lib/browserify-rails/railtie.rb
+++ b/lib/browserify-rails/railtie.rb
@@ -15,7 +15,7 @@ module BrowserifyRails
     config.browserify_rails.evaluate_node_modules = false
 
     # Environments to generate source maps in
-    config.browserify_rails.source_map_environments = ["development"]
+    config.browserify_rails.source_map_environments = []
 
     # Use browserifyinc instead of browserify
     config.browserify_rails.use_browserifyinc = true


### PR DESCRIPTION
By default, we did have `development` environment getting source maps generated. Some people want them, some do not. I think it would make more sense to have explicit configuration.

See https://github.com/browserify-rails/browserify-rails/issues/40 for example of this coming up.

What do you think?