### PR TITLE
Move cache to a clearable location

### DIFF
--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -28,7 +28,7 @@ module BrowserifyRails
     end
 
     def tmp_path
-      @tmp_path ||= Rails.root.join("tmp", "browserify-rails").freeze
+      @tmp_path ||= Rails.root.join("tmp", "cache", "browserify-rails").freeze
     end
 
     def browserify_cmd

--- a/test/compilation_test.rb
+++ b/test/compilation_test.rb
@@ -15,7 +15,7 @@ class BrowserifyTest < ActionController::IntegrationTest
     # Reset config on each run
     Dummy::Application.config.browserify_rails.force = false
 
-    cache_file = File.join(Rails.root, "tmp/browserify-rails/browserifyinc-cache.json")
+    cache_file = File.join(Rails.root, "tmp/cache/browserify-rails/browserifyinc-cache.json")
     File.delete(cache_file) if File.exists?(cache_file)
 
     copy_example_file "application.js.example"


### PR DESCRIPTION
The default Rails `rake tmp:cache:clear` task only removes files below `tmp/cache` (see [tmp.rake](https://github.com/rails/rails/blob/862c8c65a3ae8615dd30a0a2392aeaaf083d2b2f/railties/lib/rails/tasks/tmp.rake#L20)). The browserify-inc cachefile is above this (`tmp/browserify-rails`) so the only way to clear it is by hand.

This just moves the browserify cache one level down so the task will actually clear it, as recommended in the Readme.