### PR TITLE
Allow overriding NODE_ENV in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ class My::Application < Rails::Application
 
   # or as a string:
   config.browserify_rails.commandline_options = "-t browserify-shim --fast"
+
+  # Define NODE_ENV to be used with envify
+  #
+  # defaults to Rails.env
+  config.browserify_rails.node_env = "production"
 ```
 
 ### browserify-incremental

--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -121,7 +121,7 @@ module BrowserifyRails
     def env
       {
         "NODE_PATH" => asset_paths,
-        "NODE_ENV"  => Rails.env
+        "NODE_ENV"  => config.node_env || Rails.env
       }
     end
 

--- a/test/browserify_processor_test.rb
+++ b/test/browserify_processor_test.rb
@@ -40,7 +40,13 @@ class BrowserifyProcessorTest < ActiveSupport::TestCase
     assert_equal "-d -i test4.js", @processor.send(:options)
   end
 
-  test "env should have NODE_ENV set" do
+  test "env should have NODE_ENV set to Rails.application.config.browserify_rails.node_env" do
+    Rails.application.config.browserify_rails.node_env = "staging"
+    assert_equal "staging", @processor.send(:env)["NODE_ENV"]
+  end
+
+  test "env should have NODE_ENV default to Rails.env" do
+    Rails.application.config.browserify_rails.node_env = nil
     assert_equal Rails.env, @processor.send(:env)["NODE_ENV"]
   end
 


### PR DESCRIPTION
Setting NODE_ENV to Rails.env is a good default, but in staging environment it might be desirable to use  "production". This is necessary to compile a non-debug build of React.