### PR TITLE
Make gem compatible with Rails 4.x

### DIFF
--- a/browserify-rails.gemspec
+++ b/browserify-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "sprockets", "~> 2.0"
+  spec.add_runtime_dependency "sprockets", "~> 2.2"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "coffee-rails"
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "test-unit"
 end


### PR DESCRIPTION
- Changed `sprockets` version from `~> 2.0` to `~> 2.2`.
- Added missing development dependency Test::Unit gem