### PR TITLE
Add support for piping output through Exorcist to extract sourcemaps.

### DIFF
--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -39,6 +39,10 @@ module BrowserifyRails
       @browserifyinc_cmd ||= File.join(config.node_bin, "browserifyinc").freeze
     end
 
+    def exorcist_cmd
+      @exorcist_cmd ||= rails_path(File.join(config.node_bin, "exorcist").freeze)
+    end
+
     def ensure_tmp_dir_exists!
       FileUtils.mkdir_p(rails_path(tmp_path))
     end
@@ -119,10 +123,10 @@ module BrowserifyRails
     # NODE_ENV is set to the Rails.env. This is used by some modules to determine
     # how to build. Example: https://facebook.github.io/react/downloads.html#npm
     def env
-      {
-        "NODE_PATH" => asset_paths,
-        "NODE_ENV"  => config.node_env || Rails.env
-      }
+      env_hash = {}
+      env_hash["NODE_PATH"] = asset_paths unless uses_exorcist
+      env_hash["NODE_ENV"] = config.node_env || Rails.env
+      env_hash
     end
 
     # Run the requested version of browserify (browserify or browserifyinc)
@@ -168,6 +172,26 @@ module BrowserifyRails
         raise BrowserifyRails::BrowserifyError.new("Error while running `#{command}`:\n\n#{stderr}")
       end
 
+      # If using exorcist, pipe output from browserify command into exorcist
+      if uses_exorcist && logical_path
+        if stdout.present?
+          bfy_output = stdout
+        else
+          bfy_output = output_file.read
+        end
+        sourcemap_output_file = "#{File.dirname(file)}/#{logical_path.split('/')[-1]}.map"
+        exorcist_command = "#{exorcist_cmd} #{sourcemap_output_file} #{exorcist_options}"
+        Logger::log "Exorcist: #{exorcist_command}"
+        exorcist_stdout, exorcist_stderr, exorcist_status = Open3.capture3(env,
+                                                                           exorcist_command,
+                                                                           stdin_data: bfy_output,
+                                                                           chdir: base_directory)
+
+        if !exorcist_status.success?
+          raise BrowserifyRails::BrowserifyError.new("Error while running `#{exorcist_command}`:\n\n#{exorcist_stderr}")
+        end
+      end
+
       # Read the output that was stored in the temp file
       output = output_file.read
 
@@ -177,7 +201,10 @@ module BrowserifyRails
 
       # Some command flags (such as --list) make the output go to stdout,
       # ignoring -o. If this happens, we give out stdout instead.
-      if stdout.present?
+      # If we're using exorcist, then we directly use its output
+      if uses_exorcist && exorcist_stdout.present?
+        exorcist_stdout
+      elsif stdout.present?
         stdout
       else
         output
@@ -186,6 +213,10 @@ module BrowserifyRails
 
     def uses_browserifyinc(force=nil)
       !force.nil? ? force : config.use_browserifyinc
+    end
+
+    def uses_exorcist
+      config.use_exorcist
     end
 
     def browserify_command(force=nil)
@@ -208,6 +239,13 @@ module BrowserifyRails
       options += options_to_array(config.commandline_options, file) if config.commandline_options.present?
 
       options.uniq.join(" ")
+    end
+
+    def exorcist_options
+      exorcist_options = []
+      exorcist_base_path = config.exorcist_base_path || config.root
+      exorcist_options.push("-b #{exorcist_base_path}")
+      exorcist_options.join(" ")
     end
 
     def get_granular_config(logical_path)

--- a/test/dummy/package.json
+++ b/test/dummy/package.json
@@ -6,6 +6,7 @@
     "browserify": "~> 6.2",
     "browserify-incremental": "^1.4.0",
     "coffeeify": "~> 0.6",
+    "exorcist": "~> 0.3.0",
     "node-test-package": "~> 0.0.2"
   },
   "license": "MIT",

--- a/test/fixtures/js-with-sourcemap-url.out.js
+++ b/test/fixtures/js-with-sourcemap-url.out.js
@@ -1,0 +1,16 @@
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({"__RAILS_ROOT__/app/assets/javascripts/_stream_0.js":[function(require,module,exports){
+var foo = require('./foo');
+var nodeTestPackage = require('node-test-package');
+
+},{"./foo":"__RAILS_ROOT__/app/assets/javascripts/foo.js","node-test-package":"__RAILS_ROOT__/node_modules/node-test-package/index.js"}],"__RAILS_ROOT__/app/assets/javascripts/foo.js":[function(require,module,exports){
+require('./nested');
+module.exports = function (n) { return n * 11 }
+
+},{"./nested":"__RAILS_ROOT__/app/assets/javascripts/nested/index.js"}],"__RAILS_ROOT__/app/assets/javascripts/nested/index.js":[function(require,module,exports){
+module.exports.NESTED = true;
+
+},{}],"__RAILS_ROOT__/node_modules/node-test-package/index.js":[function(require,module,exports){
+module.exports = console.log("hello friend");
+
+},{}]},{},["__RAILS_ROOT__/app/assets/javascripts/_stream_0.js"])
+//# sourceMappingURL=application.map


### PR DESCRIPTION
Adds options for piping browserify output through the exorcist library, which extracts the inline sourcemap generated by the --debug option.

This skirts around the issue mentioned in the README; if you specify that you want to use exorcist in the config, we will not set NODE_PATH, which may break compatibility with some libraries. However, if you don't use exorcist, that compatibility should be preserved.

Also exposes the -b flag in exorcist, allowing the user to specify a base path for the paths in the sourcemap. (typically just the root path)