### PR TITLE
Fixing a bug where browserify doesn't work if the directory has parentheses

### DIFF
--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -1,6 +1,7 @@
 require "open3"
 require "fileutils"
 require "tempfile"
+require "shellwords"
 
 module BrowserifyRails
   class BrowserifyProcessor < Tilt::Template
@@ -147,7 +148,7 @@ module BrowserifyRails
       # we're going to use browserifyinc.
       if uses_browserifyinc(force_browserifyinc)
         cache_file_path = rails_path(tmp_path, "browserifyinc-cache.json")
-        command_options << " --cachefile=#{cache_file_path.inspect}"
+        command_options << " --cachefile=#{Shellwords.escape(cache_file_path.inspect)}"
       end
 
       # Create a temporary file for the output. Such file is necessary when
@@ -156,7 +157,7 @@ module BrowserifyRails
       command_options << " -o #{output_file.path.inspect}"
 
       # Compose the full command (using browserify or browserifyinc as necessary)
-      command = "#{browserify_command(force_browserifyinc)} #{command_options} -"
+      command = "#{Shellwords.escape(browserify_command(force_browserifyinc))} #{command_options} -"
 
       # The directory the command will be executed from
       base_directory = File.dirname(file)


### PR DESCRIPTION
```bash
/Users/ricky/.rvm/gems/ruby-2.2.2/gems/browserify-rails-0.9.1/lib/browserify-rails/browserify_processor.rb:203: warning: circular argument reference - file
D, [2015-06-03T11:15:16.704448 #80424] DEBUG -- : ** [Raven] Event not sent due to excluded environment: default
rake aborted!
BrowserifyRails::BrowserifyError: Error while running `/Users/ricky/Dropbox (Personal)/Sites/testapp/node_modules/.bin/browserifyinc --transform [reactify --harmony --extension=".jsx"] --list --cachefile="/Users/ricky/Dropbox (Personal)/Sites/testapp/tmp/cache/browserify-rails/browserifyinc-cache.json" -o "/Users/ricky/Dropbox (Personal)/Sites/testapp/tmp/cache/browserify-rails/output20150603-80424-1xdx16s" -`:

sh: -c: line 0: syntax error near unexpected token `Personal'
sh: -c: line 0: `/Users/ricky/Dropbox (Personal)/Sites/testapp/node_modules/.bin/browserifyinc --transform [reactify --harmony --extension=".jsx"] --list --cachefile="/Users/ricky/Dropbox (Personal)/Sites/testapp/tmp/cache/browserify-rails/browserifyinc-cache.json" -o "/Users/ricky/Dropbox (Personal)/Sites/testapp/tmp/cache/browserify-rails/output20150603-80424-1xdx16s" -'

  (in /Users/ricky/Dropbox (Personal)/Sites/testapp/app/assets/javascripts/components.js)/Users/ricky/.rvm/gems/ruby-2.2.2/gems/browserify-rails-0.9.1/lib/browserify-rails/browserify_processor.rb:168:in `run_browserify'
/Users/ricky/.rvm/gems/ruby-2.2.2/gems/browserify-rails-0.9.1/lib/browserify-rails/browserify_processor.rb:104:in `dependencies'
/Users/ricky/.rvm/gems/ruby-2.2.2/gems/browserify-rails-0.9.1/lib/browserify-rails/browserify_processor.rb:81:in `commonjs_module?'
/Users/ricky/.rvm/gems/ruby-2.2.2/gems/browserify-rails-0.9.1/lib/browserify-rails/browserify_processor.rb:61:in `should_browserify?'
/Users/ricky/.rvm/gems/ruby-2.2.2/gems/browserify-rails-0.9.1/lib/browserify-rails/browserify_processor.rb:14:in `evaluate'
/Users/ricky/.rvm/gems/ruby-2.2.2/gems/tilt-1.4.1/lib/tilt/template.rb:103:in `render'
/Users/ricky/.rvm/gems/ruby-2.2.2/gems/sprockets-2.12.3/lib/sprockets/context.rb:197:in `block in evaluate'
/Users/ricky/.rvm/gems/ruby-2.2.2/gems/sprockets-2.12.3/lib/sprockets/context.rb:194:in `each'
/Users/ricky/.rvm/gems/ruby-2.2.2/gems/sprockets-2.12.3/lib/sprockets/context.rb:194:in `evaluate'
/Users/ricky/.rvm/gems/ruby-2.2.2/gems/sprockets-2.12.3/lib/sprockets/processed_asset.rb:12:in `initialize'
/Users/ricky/.rvm/gems/ruby-2.2.2/gems/sprockets-2.12.3/lib/sprockets/base.rb:374:in `new'
/Users/ricky/.rvm/gems/ruby-2.2.2/gems/sprockets-2.12.3/lib/sprockets/base.rb:374:in `block in build_asset'
/Users/ricky/.rvm/gems/ruby-2.2.2/gems/sprockets-2.12.3/lib/sprockets/base.rb:395:in `circular_call_protection'
/Users/ricky/.rvm/gems/ruby-2.2.2/gems/sprockets-2.12.3/lib/sprockets/base.rb:373:in `build_asset'
/Users/ricky/.rvm/gems/ruby-2.2.2/gems/sprockets-2.12.3/lib/sprockets/index.rb:94:in `block in build_asset'
/Users/ricky/.rvm/gems/ruby-2.2.2/gems/sprockets-2.12.3/lib/sprockets/caching.rb:58:in `cache_asset'
```