### PR TITLE
Change suggested version in readme to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It lets you mix and match  `//= require` directives and `require()` calls for in
 
 Add this line to your application's Gemfile:
 
-    gem "browserify-rails", "~> 0.7"
+    gem "browserify-rails", "~> 1.0.1"
 
 Create `package.json` in your Rails root:
 


### PR DESCRIPTION
I am unsure if there is a reason the readme suggests that a user installs 0.7, but I was unable to do that as it requires sprockets 2, which clashes with `sprockets-es6`'s requirement of `sprockets, >=3.0.0.beta`.

I had the impression that this project might not be maintained as a result, so I figure this is worth updating.