### PR TITLE
Correct cachefile command line option

### DIFF
--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -156,7 +156,7 @@ module BrowserifyRails
       # we're going to use browserifyinc.
       if uses_browserifyinc(force_browserifyinc)
         cache_file_path = rails_path(tmp_path, "browserifyinc-cache.json")
-        command_options << " --cachefile=#{Shellwords.escape(cache_file_path.inspect)}"
+        command_options << " --cachefile=#{Shellwords.escape(cache_file_path)}"
       end
 
       # Create a temporary file for the output. Such file is necessary when
@@ -172,6 +172,8 @@ module BrowserifyRails
 
       Logger::log "Browserify: #{command}"
       stdout, stderr, status = Open3.capture3(env, command, stdin_data: data, chdir: base_directory)
+
+      puts Dir.entries(rails_path(tmp_path))
 
       if !status.success?
         raise BrowserifyRails::BrowserifyError.new("Error while running `#{command}`:\n\n#{stderr}")

--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -173,8 +173,6 @@ module BrowserifyRails
       Logger::log "Browserify: #{command}"
       stdout, stderr, status = Open3.capture3(env, command, stdin_data: data, chdir: base_directory)
 
-      puts Dir.entries(rails_path(tmp_path))
-
       if !status.success?
         raise BrowserifyRails::BrowserifyError.new("Error while running `#{command}`:\n\n#{stderr}")
       end


### PR DESCRIPTION
With the combination of `Shellwords.escape` and `#inspect`, the generated commandline cachefile path was `--cachefile=\"{Rails.root}/tmp/cache/browserify-rails/browserifyinc-cache.json\"`.  With the path in this escaped format, browserify-incremental silently refused to output a cachefile (as you can see by running `ls tmp/cache/browserify-rails` from your project root directory).  This nullified any benefit of using browserify-incremental over vanilla browserify.

Removing inspect changes the output to  `--cachefile={Rails.root}/tmp/cache/browserify-rails/browserifyinc-cache.json`.  With this change, browserify-incremental stores the cachefile as expected (as you can see, again, by running `ls tmp/cache/browserify-rails` from the project root directory).

This should help with some of the concerns in #43.