### PR TITLE
Bump version and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file going forward.
 
+## [1.3.0] - 2015-08-12
+- add tilt >= 2.0.1 as a runtime dependency (overlooked)
+
 ## [1.2.0] - 2015-07-19
 - require sprockets > 3.0.2 (see browserify-rails issue 91)
 

--- a/browserify-rails.gemspec
+++ b/browserify-rails.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "railties", ">= 4.0.0", "< 5.0"
   spec.add_runtime_dependency "sprockets", "> 3.0.2"
+  spec.add_runtime_dependency "tilt", ">= 2.0.1"
 
   spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "rake"
@@ -29,5 +30,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "test-unit"
-  spec.add_development_dependency "tilt"
 end

--- a/lib/browserify-rails/version.rb
+++ b/lib/browserify-rails/version.rb
@@ -1,3 +1,3 @@
 module BrowserifyRails
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
This resolves issue https://github.com/browserify-rails/browserify-rails/issues/105. The `tilt` gem is a runtime dependency but the `gemspec` didn't have it as one.