### PR TITLE
Make config.force more flexible allowing it to be a proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,11 @@ class My::Application < Rails::Application
   # The default is `false`
   config.browserify_rails.evaluate_node_modules = true
 
-  # Force browserify on every found JavaScript asset
+  # Force browserify on every found JavaScript asset if true.
+  # Can be a proc.
   #
   # The default is `false`
-  config.browserify_rails.force = true
+  config.browserify_rails.force = ->(file) { File.extname(file) == ".ts" }
 
   # Command line options used when running browserify
   #

--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -67,7 +67,15 @@ module BrowserifyRails
     end
 
     def should_browserify?
-      config.force || (in_path? && !browserified? && commonjs_module?)
+      force_browserify? || (in_path? && !browserified? && commonjs_module?)
+    end
+
+    def force_browserify?
+      if config.force.is_a? Proc
+        config.force.call file
+      else
+        config.force
+      end
     end
 
     # Is this file in any of the configured paths?

--- a/lib/browserify-rails/railtie.rb
+++ b/lib/browserify-rails/railtie.rb
@@ -4,7 +4,7 @@ module BrowserifyRails
   class Railtie < Rails::Engine
     config.browserify_rails = ActiveSupport::OrderedOptions.new
 
-    # Always browserify every file
+    # Browserify every file if true. Can be a proc.
     config.browserify_rails.force = false
 
     # Which paths should be browserified?


### PR DESCRIPTION
it allows us to browserify `application.js` by renaming it to `application.coffee` or `application.ts` and checking extension.