### PR TITLE
Minor change results in module name being slightly different

### DIFF
--- a/test/fixtures/main.out.js
+++ b/test/fixtures/main.out.js
@@ -5,7 +5,7 @@ module.exports = function() {
   console.log('library', library);
 };
 
-},{"./a_huge_library":"__RAILS_ROOT__/app/assets/javascripts/a_huge_library.js"}],"__RAILS_ROOT__/app/assets/javascripts/a_huge_library.js":[function(require,module,exports){
+},{"./a_huge_library":"__RAILS_ROOT__/app/assets/javascripts/a_huge_library.js"}],"a_huge_library":[function(require,module,exports){
 // pretend this file is 1 MB
 //
 // app_main.js is going to require() it and browserify.yml is going to tell it to use --require on it


### PR DESCRIPTION
Get tests passing -- if this results in failure for you, `rm -rf test/dummy/node_modules`. We should probably freeze them but working with current node module install seems more sane.