### PR TITLE
Remove tilt and use callable sprockets api

### DIFF
--- a/test/browserify_processor_test.rb
+++ b/test/browserify_processor_test.rb
@@ -6,11 +6,8 @@ class BrowserifyProcessorTest < ActiveSupport::TestCase
   end
 
   setup do
-    template = "empty_module.js"
-    @empty_module = fixture(template)
-    @processor = BrowserifyRails::BrowserifyProcessor.new(template) do |p|
-      @empty_module
-    end
+    @processor = BrowserifyRails::BrowserifyProcessor.new
+    @processor.file = "empty_module.js"
   end
 
   test "should run command without options if none provided" do


### PR DESCRIPTION
Hello there!

With Rails 5 right on the corner, which depends on sprockets 4, tilt processors will stop to work.

We currently depends on `railties  >= 4.0.0`, which depends on `sprockets > 3`, 
so we will not reduce compatibility.

This PR remove Tilt, and use the new `callable` sprockets api.

Sorry for my english,

thanks!