### PR TITLE
[bug] pass up to sprockets correct dependencies

### DIFF
--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -33,8 +33,8 @@ module BrowserifyRails
 
       # Signal dependencies to sprockets to ensure we track changes
       evaluate_dependencies(input[:environment].paths).each do |path|
-        resolved =  input[:environment].resolve(path)
-        dependencies << resolved.last.first if resolved
+        resolved = input[:environment].resolve(path)
+        dependencies << "file-digest://#{resolved}" if resolved
       end
 
       new_data = run_browserify(input[:name])


### PR DESCRIPTION
When we passed metadata back up to sprockets for the file that we are
running browserify on, the dependencies set had a bug in that it was
being inserted as:

dependencies << resolved.last.first if resolved

This resulted in a single character from the filename being inserted
instead of the correct file-digest://#{path}.

resolves #101