### PR TITLE
allow the use of "require" in files.

### DIFF
--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -106,7 +106,7 @@ module BrowserifyRails
     # Be here as strict as possible, so that non-commonjs files are not
     # preprocessed.
     def commonjs_module?
-      data.to_s.include?("module.exports") || data.present? && data.to_s.include?("require") && dependencies.length > 0
+      data.to_s.include?("module.exports") || data.present? && data.to_s.match(/require\(.*\)/) && dependencies.length > 0
     end
 
     def asset_paths

--- a/test/compilation_test.rb
+++ b/test/compilation_test.rb
@@ -25,6 +25,7 @@ class BrowserifyTest < ActionDispatch::IntegrationTest
     copy_example_file "coffee.js.coffee.example"
     copy_example_file "node_path_based_require.js.example"
     copy_example_file "main.js.example"
+    copy_example_file "require_in_a_comment.js.example"
     copy_example_file "secondary.js.example"
     copy_example_file "a_huge_library.js.example"
     copy_example_file "some_folder/answer.js.example"
@@ -161,6 +162,12 @@ class BrowserifyTest < ActionDispatch::IntegrationTest
     get "/assets/plain.js"
 
     assert_equal fixture("plain.js"), @response.body.strip
+  end
+
+  test "skip files containing the word require in comments" do
+    get "/assets/require_in_a_comment.js"
+
+    assert_equal fixture("require_in_a_comment.js"), @response.body.strip
   end
 
   test "browserify even plain files if force == true" do

--- a/test/dummy/app/assets/javascripts/require_in_a_comment.js.example
+++ b/test/dummy/app/assets/javascripts/require_in_a_comment.js.example
@@ -1,0 +1,3 @@
+// I'm a comment with the word require in me!
+
+var hi = "nothing else noteworthy about me.";

--- a/test/fixtures/require_in_a_comment.js
+++ b/test/fixtures/require_in_a_comment.js
@@ -1,0 +1,3 @@
+// I'm a comment with the word require in me!
+
+var hi = "nothing else noteworthy about me.";


### PR DESCRIPTION
Hi there, I just ran into an issue where the word "require" was in a comment inside a JavaScript file, and within a string in a different one. For some reason, this was causing Browserify to break in a very unexpected (and hard to track down!) way.

I've added a test case for this, and changed how it checks for require statements from
`include?("require")` to `match(/require\(.*\)/)`.

Let me know if there's anything else you need!