### PR TITLE
Escape the file path

### DIFF
--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -40,7 +40,7 @@ module BrowserifyRails
         if config.evaluate_node_modules && !resolved
           resolved = path
         end
-        dependencies << "file-digest://#{resolved}" if resolved
+        dependencies << "file-digest://#{URI.escape resolved}" if resolved
       end
 
       new_data = run_browserify(input[:name])


### PR DESCRIPTION
Without this change, paths with spaces (and any other URI-incompatible
characters) would cause browserify-rails to fail.

I tested this locally, but I'm not sure how to run the tests for this project.