### PR TITLE
Require sprockets >= 3.5.2

### DIFF
--- a/browserify-rails.gemspec
+++ b/browserify-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
 
   spec.add_runtime_dependency "railties", ">= 4.0.0", "< 5.0"
-  spec.add_runtime_dependency "sprockets", "> 3.0.2"
+  spec.add_runtime_dependency "sprockets", ">= 3.5.2"
 
   spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Resolves https://github.com/browserify-rails/browserify-rails/issues/135. Sprockets 3.5.2 is the current latest which may be incompatible with some versions of Rails. But this fixes it for current rails and we can adjust it if needed for prior versions of rails.