### PR TITLE
Support import

### DIFF
--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -112,7 +112,7 @@ module BrowserifyRails
     # Be here as strict as possible, so that non-commonjs files are not
     # preprocessed.
     def commonjs_module?
-      data.to_s.include?("module.exports") || data.present? && data.to_s.match(/require\(.*\)/) && dependencies.length > 0
+      data.to_s.include?("module.exports") || data.present? && data.to_s.match(/(require\(.*\)|import)/) && dependencies.length > 0
     end
 
     def asset_paths

--- a/test/compilation_test.rb
+++ b/test/compilation_test.rb
@@ -32,6 +32,8 @@ class BrowserifyTest < ActionDispatch::IntegrationTest
     copy_example_file "some_folder/answer.js.example"
     copy_example_file "browserified.js.example"
     copy_example_file "index.js.example", "node_modules/node-test-package"
+    copy_example_file "simple_module.js.example"
+    copy_example_file "use_import.js.example"
   end
 
   test "asset pipeline should serve application.js" do
@@ -277,5 +279,20 @@ class BrowserifyTest < ActionDispatch::IntegrationTest
     get "/assets/application.js"
 
     assert_match /BrowserifyRails::BrowserifyError/, @response.body
+  end
+
+  test "identifies files that call import function as modules" do
+    Dummy::Application.config.browserify_rails.commandline_options = "-t [ babelify --presets [ es2015 ] ]"
+
+    begin
+      expected_output = fixture("use_import.out.js")
+
+      get "/assets/use_import.js"
+
+      assert_response :success
+      assert_equal expected_output, @response.body.strip
+    ensure
+      Dummy::Application.config.browserify_rails.commandline_options = ""
+    end
   end
 end

--- a/test/dummy/app/assets/javascripts/simple_module.js.example
+++ b/test/dummy/app/assets/javascripts/simple_module.js.example
@@ -1,0 +1,3 @@
+export default function() {
+  return 42;
+}

--- a/test/dummy/app/assets/javascripts/use_import.js.example
+++ b/test/dummy/app/assets/javascripts/use_import.js.example
@@ -1,0 +1,3 @@
+import universe from './simple_module';
+
+console.log(universe());

--- a/test/dummy/package.json
+++ b/test/dummy/package.json
@@ -2,10 +2,13 @@
   "name": "dummy",
   "author": "Henry Hsu <hhsu@zendesk.com>",
   "description": "a dummy Rails application",
-  "devDependencies" : {
-    "browserify": "~> 6.2",
-    "browserify-incremental": "^1.4.0",
-    "coffeeify": "~> 0.6",
+  "devDependencies": {
+    "babel": "6.3.26",
+    "babel-preset-es2015": "^6.6.0",
+    "babelify": "7.2.0",
+    "browserify": "6.3.4",
+    "browserify-incremental": "3.0.1",
+    "coffeeify": "2.0.1",
     "exorcist": "~> 0.3.0",
     "node-test-package": "~> 0.0.2"
   },

--- a/test/fixtures/use_import.out.js
+++ b/test/fixtures/use_import.out.js
@@ -1,0 +1,23 @@
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({"/Users/cymen/dev/browserify-rails/test/dummy/app/assets/javascripts/_stream_0.js":[function(require,module,exports){
+'use strict';
+
+var _simple_module = require('./simple_module');
+
+var _simple_module2 = _interopRequireDefault(_simple_module);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+console.log((0, _simple_module2.default)());
+
+},{"./simple_module":"/Users/cymen/dev/browserify-rails/test/dummy/app/assets/javascripts/simple_module.js"}],"/Users/cymen/dev/browserify-rails/test/dummy/app/assets/javascripts/simple_module.js":[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = function () {
+  return 42;
+};
+
+},{}]},{},["/Users/cymen/dev/browserify-rails/test/dummy/app/assets/javascripts/_stream_0.js"]);


### PR DESCRIPTION
Add support for detecting the import keyword and processing the input as a JavaScript module. Note this will cause issues if people have ES6 code present that contains `import` yet haven't configured bableify for es6!