### PR TITLE
Relax railties requirement to < 5.1

### DIFF
--- a/browserify-rails.gemspec
+++ b/browserify-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_runtime_dependency "railties", ">= 4.0.0", "< 5.0"
+  spec.add_runtime_dependency "railties", ">= 4.0.0", "< 5.1"
   spec.add_runtime_dependency "sprockets", ">= 3.5.2"
 
   spec.add_development_dependency "bundler", ">= 1.3"


### PR DESCRIPTION
This allows installation with Rails 5.x.