### PR TITLE
Normalizes the dependency paths returned from browserify to work in Windows

### DIFF
--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -142,7 +142,12 @@ module BrowserifyRails
         # option to get a list of files.
         list = run_browserify(nil, "--list")
 
-        list.lines.map(&:strip).select do |path|
+        cleaned_paths = list.lines.map do |path|
+          # clean and normalize paths for all operating systems
+          Pathname.new(path.strip).cleanpath.to_s
+        end
+
+        cleaned_paths.select do |path|
           # Filter the temp file, where browserify caches the input stream
           File.exist?(path)
         end


### PR DESCRIPTION
Paths returned from ```browserifyinc --list``` are in the native operating system format, however the asset_paths they are checked against in evaluate_dependencies use forward slashes, regardless of operating system. This pull request calls ```Pathname.new(path.strip).cleanpath.to_s``` on the paths returned from ```browserifyinc --list``` to make sure starts_with? comparisons in evaluate_dependencies work correctly, regardless of operating system.