### PR TITLE
Short circuit when provided paths is not in configured paths (config.browserify_rails.paths)

### DIFF
--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -21,8 +21,9 @@ module BrowserifyRails
     end
 
     def call(input)
-      self.data = input[:data]
       self.file = input[:filename]
+      return input[:data] unless in_path?
+      self.data = input[:data]
 
       # Clear the cached dependencies because the source file changes
       @dependencies = nil


### PR DESCRIPTION
Maybe I'm not setting up browserify-rails the right way but this change increased speed of browserify'ing by 20% for us from an empty cache resulting in faster builds in our CI.