### PR TITLE
Docs: Help people upgrade to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 All notable changes to this project will be documented in this file going forward.
 
 ## [4.0.0] - 2017-02-07
-- depend on sprockets >= 3.6.0 and change to new API usage (#11f7c3c)
+- depend on sprockets >= 3.6.0 
+  (https://github.com/browserify-rails/browserify-rails/commit/11f7c3c)
 
 ## [3.4.0] - 2016-11-22
 - speeds up build by up to 20% thanks to cguillemette (see PR #183)


### PR DESCRIPTION
The changelog should clearly state whether 4.0.0 is a change to the public API of `browserify-rails` or not.

The phrase "change to new API usage" seems to refer to the new sprockets version constraint, but could be misinterpreted to mean that the public API of `browserify-rails` has changed. Maybe it is more clear to simply say "depend on sprockets >= 3.6.0"?