### PR TITLE
Update version of browserify in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Create `package.json` in your Rails root:
 
 ```js
 {
-  "name": "something",
+  "name": "my-rails-app",
   "dependencies" : {
-    "browserify": "~10.2.4",
-    "browserify-incremental": "^3.0.1"
+    "browserify": "^14.1.0",
+    "browserify-incremental": "^3.1.1"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
This is a pull request, but it's really a question, ie. does browserify-rails support the latest browserify (currently 14.1.0)?

I made a PR just in case you wanted to have the latest version number in the readme.

I changed the tilde to a caret because that's what my team uses, but again, maybe not what you want in the readme.

Thanks!