### PR TITLE
Re-open the output file before reading the results from browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Create `package.json` in your Rails root:
 {
   "name": "something",
   "dependencies" : {
-    "browserify": "~10.2.4",
-    "browserify-incremental": "^3.0.1"
+    "browserify": "^14.0.0",
+    "browserify-incremental": "^3.1.0"
   },
   "license": "MIT",
   "engines": {

--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -242,6 +242,7 @@ module BrowserifyRails
       end
 
       # Read the output that was stored in the temp file
+      output_file.open
       output = output_file.read
 
       # Destroy the temp file (good practice)

--- a/test/compilation_test.rb
+++ b/test/compilation_test.rb
@@ -295,4 +295,19 @@ class BrowserifyTest < ActionDispatch::IntegrationTest
       Dummy::Application.config.browserify_rails.commandline_options = ""
     end
   end
+
+  test "generates files under plain browserify with browserifyinc disabled" do
+    Dummy::Application.config.browserify_rails.use_browserifyinc = false
+
+    begin
+      expected_output = fixture("main.out.js")
+
+      get "/assets/main.js"
+
+      assert_response :success
+      assert_equal expected_output, @response.body.strip
+    ensure
+    Dummy::Application.config.browserify_rails.use_browserifyinc = true
+    end
+  end
 end

--- a/test/dummy/package.json
+++ b/test/dummy/package.json
@@ -6,7 +6,7 @@
     "babel": "6.3.26",
     "babel-preset-es2015": "^6.6.0",
     "babelify": "7.2.0",
-    "browserify": "13.1.0",
+    "browserify": "14.1.0",
     "browserify-incremental": "3.1.1",
     "coffeeify": "2.0.1",
     "exorcist": "~> 0.3.0",


### PR DESCRIPTION
This issue raised its head with changes to browserify for 14.1.0. This
version introduces a two-step process for generating results in which
results are written to a new file and then copied into the path
designated in the options. This means that the file handle
browserify-rails has from `Tempfile` is no longer valid and is always
empty.

This is further complicated in that it is only a situation when running
browserify directly and not browserifyinc. I noticed there weren't any
tests disabling browserifyinc so hit two issues with one test.

One further note, there are two test failures here related to exorcist that are
also failing on master and do not seem related to the changes made here.