### PR TITLE
Relax railties dependency for Rails-5.1

### DIFF
--- a/browserify-rails.gemspec
+++ b/browserify-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_runtime_dependency "railties", ">= 4.0.0", "< 5.1"
+  spec.add_runtime_dependency "railties", ">= 4.0.0", "< 5.2"
   spec.add_runtime_dependency "sprockets", ">= 3.6.0"
   spec.add_runtime_dependency "addressable", ">= 2.4.0"
 


### PR DESCRIPTION
Since Rails 5.1 has been officially released, let's allow [railties 5.1](https://rubygems.org/gems/railties/versions/5.1.0) so that we can use browserify-rails on Rails 5.1.

[Rails 5.1: Loving JavaScript, System Tests, Encrypted Secrets, and more | Riding Rails](http://weblog.rubyonrails.org/2017/4/27/Rails-5-1-final/)