### PR TITLE
Support Rails 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Change Log
 All notable changes to this project will be documented in this file going forward.
 
+## [4.2.0] - 2017-04-28
+- relax railties requirement to < 5.2
+
 ## [4.1.0] - 2017-02-25
 - makes compatible with browserify 14.1.0
   see: https://github.com/browserify-rails/browserify-rails/pull/193
 
 ## [4.0.0] - 2017-02-07
-- depend on sprockets >= 3.6.0 
+- depend on sprockets >= 3.6.0
   (https://github.com/browserify-rails/browserify-rails/commit/11f7c3c)
 
 ## [3.4.0] - 2016-11-22

--- a/browserify-rails.gemspec
+++ b/browserify-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_runtime_dependency "railties", ">= 4.0.0", "< 5.1"
+  spec.add_runtime_dependency "railties", ">= 4.0.0", "< 5.2"
   spec.add_runtime_dependency "sprockets", ">= 3.6.0"
   spec.add_runtime_dependency "addressable", ">= 2.4.0"
 

--- a/lib/browserify-rails/version.rb
+++ b/lib/browserify-rails/version.rb
@@ -1,3 +1,3 @@
 module BrowserifyRails
-  VERSION = "4.1.0"
+  VERSION = "4.2.0"
 end


### PR DESCRIPTION
Rails 5.1 release has been officially cut http://weblog.rubyonrails.org/2017/4/27/Rails-5-1-final/

I don't _think_ the changes to build pipeline should affect this Gem?